### PR TITLE
Debian backport: Fix Segfault due to uninitialized Variable

### DIFF
--- a/main.c
+++ b/main.c
@@ -2027,7 +2027,7 @@ static GtkWidget *create_main_window_menu_bar()
 //  GtkUIManager *uimanager;
   GtkActionGroup *actgroup;
   GtkAction *item;
-  GError *err;
+  GError *err = NULL;
 
   actgroup = gtk_action_group_new("ActionMain");
   // set translation domain and function


### PR DESCRIPTION
This is another patch bundled with the debian package. Description copied from there without changes.

--- 

A pointer intended to hold a possible error message was not initialized prior
 to being passed to the corresponding gtk function. Initialize the pointer with NULL.
Author: Willi Mann <willi@debian.org>
Bug-Debian: http://bugs.debian.org/668663