### PR TITLE
small fix: the monthly report did not work because of a small typo

### DIFF
--- a/main.c
+++ b/main.c
@@ -1368,7 +1368,7 @@ static void report2_callback ( GtkAction *act )
   const TTarray acts[] = {
 	{"RM_Daily", REPORT_TYPE_DAILY},
 	{"RM_Weekly", REPORT_TYPE_WEEKLY},
-	{"RM_MOnthly", REPORT_TYPE_MONTHLY},
+	{"RM_Monthly", REPORT_TYPE_MONTHLY},
 	{"RM_Yearly", REPORT_TYPE_YEARLY}
    };
   const gchar *aname = gtk_action_get_name(GTK_ACTION(act));


### PR DESCRIPTION
Hello, I'm using gtimer and noticed that the monthly report was not working: the reason was a small typo soI fixed it. A branch is overkill for a small fix like this but I did not want to put my changes in master. 

have a nice day
Francesco