### PR TITLE
docs: add non-/usr prefix wrapper script to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ Alternatively point `GSETTINGS_SCHEMA_DIR` directly at the compiled schema:
 export GSETTINGS_SCHEMA_DIR="<prefix>/share/glib-2.0/schemas"
 ```
 
+To avoid setting an environment variable in every shell, you can install a
+small wrapper script inside the prefix and put it on your `$PATH` instead of
+`<prefix>/bin`. Create `<prefix>/wrap/gtimer` with:
+
+```sh
+#!/bin/sh
+DIR=$(dirname "$0") && cd "$DIR" && cd ..
+export GSETTINGS_SCHEMA_DIR="./share/glib-2.0/schemas/"
+exec ./bin/gtimer
+```
+
+Make it executable (`chmod +x <prefix>/wrap/gtimer`) and add `<prefix>/wrap` to
+your `$PATH`. The wrapper resolves the schema directory relative to its own
+location, so it keeps working even if the prefix is moved.
+(Thanks to [@sedererdj](https://github.com/sedererdj) for this approach — see
+[#10](https://github.com/craigk5n/gtimer/issues/10).)
+
 ## Command Line Usage
 
 GTimer supports command line options for scripting and automation:


### PR DESCRIPTION
## Summary

Documents a wrapper-script approach for running GTimer when installed to a **non-`/usr` prefix**, so users don't have to set `GSETTINGS_SCHEMA_DIR`/`XDG_DATA_DIRS` in every shell.

The wrapper resolves the compiled schema directory relative to its own location (`<prefix>/share/glib-2.0/schemas/`), so it keeps working even if the prefix is moved. Added to the **Install** section of the README, right after the existing env-var instructions.

Contributed by @sedererdj in #10.

## Test plan

- [ ] Render-check the README Install section
- [ ] (Optional) Verify the wrapper launches a `--prefix=/somedir` install cleanly without per-shell env setup
